### PR TITLE
Adding orderId/TransactionId to .getPurchaseData 

### DIFF
--- a/lib/apple.js
+++ b/lib/apple.js
@@ -89,6 +89,7 @@ module.exports.getPurchaseData = function (purchase) {
 		for (var i = 0, len = purchase.receipt.in_app.length; i < len; i++) {
 			var item = purchase.receipt.in_app[i];
 			data.push({
+				transactionId: item.transaction_id,
 				productId: item.product_id,
 				purchaseDate: item.original_purchase_date_ms,
 				quantity: parseInt(item.quantity, 10)
@@ -98,6 +99,7 @@ module.exports.getPurchaseData = function (purchase) {
 	}
 	// old and will be deprecated by Apple
 	data.push({
+		transactionId:  purchase.receipt.transaction_id,
 		productId: purchase.receipt.product_id,
 		purchaseDate: purchase.receipt.original_purchase_date_ms,
 		quantity: parseInt(purchase.receipt.quantity, 10)

--- a/lib/google.js
+++ b/lib/google.js
@@ -130,6 +130,7 @@ module.exports.getPurchaseData = function (purchase) {
 	}
 	var data = [];
 	data.push({
+		transactionId: purchase.orderId,
 		productId: purchase.productId,
 		purchaseDate: purchase.purchaseTime,
 		quantity: 1


### PR DESCRIPTION
This is so a validation server can keep a record of transactions and protect against resubmitted receipts.

