### PR TITLE
Adds support for setting a default Request configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,13 @@ inAppPurchase.config({
 });
 ```
 
+#### HTTP Request Configuration
+
+The module utilises the Request module for the HTTP requests required to validate Apple and Windows IAP subscriptions. The default settings for requests can be configured by passing in the `requestDefaults` configuration property. This allows you to configure proxies, tunnels and request timeouts. This object can contain any [Request module options](https://github.com/request/request#requestoptions-callback) but may be overridden by request-specific options set by this module.
+
 ### GooglePlay Public Key From Environment Variables
 
-For GooglePlay, `in-app-purchase` module can read public key value from the environement variables instead of file(s).
+For GooglePlay, `in-app-purchase` module can read public key value from the environment variables instead of file(s).
 
 The basics is the same as using file(s).
 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports.WINDOWS = constants.SERVICES.WINDOWS;
 module.exports.config = function (configIn) {
 	apple.readConfig(configIn);
 	google.readConfig(configIn);
+	windows.readConfig(configIn);
 };
 
 module.exports.setup = function (cb) {

--- a/lib/apple.js
+++ b/lib/apple.js
@@ -27,6 +27,10 @@ module.exports.readConfig = function (configIn) {
 	}
 	config = {};
 	var configValueSet = false;
+	// Apply any default settings to Request.
+	if('requestDefaults' in configIn) {
+		request = request.defaults(configIn.requestDefaults);
+	}
 	Object.keys(configIn).forEach(function (key) {
 		if (isValidConfigKey(key)) {
 			config[key] = configIn[key];

--- a/lib/windows.js
+++ b/lib/windows.js
@@ -6,6 +6,17 @@ var request = require('request');
 var url = 'https://lic.apps.microsoft.com/licensing/certificateserver/?cid=';
 var sigXPath = '//*//*[local-name(.)=\'Signature\' and namespace-uri(.)=\'http://www.w3.org/2000/09/xmldsig#\']';
 
+module.exports.readConfig = function (configIn) {
+	if (!configIn) {
+	    // no required config
+	    return;
+	}
+	// Apply any default settings to Request.
+	if ('requestDefaults' in configIn) {
+		request = request.defaults(configIn.requestDefaults);
+	}
+};
+
 // receipt is an XML string... oh microsoft... why?
 module.exports.validatePurchase = function (receipt, cb) {
 	var json;


### PR DESCRIPTION
Adds the ability to configure options for HTTP requests using the Request default configuration options. In-app-purchase's options will still override any user-set defaults if the specific validator sets a Request option value explicitly. This allows developers to utilise in-app-purchase when utilising proxies, tunnels and allows them to set custom timeouts amongst other things. 

This also corrects a typographical error in readme.md. 