### PR TITLE
Remove redundant 'Content-Type' header definition

### DIFF
--- a/lib/apple.js
+++ b/lib/apple.js
@@ -121,9 +121,6 @@ function send(url, content, cb) {
 	var options = {
 		encoding: null,
 		url: url,
-		headers: {
-			'Content-Type': 'application/x-www-form-urlencoded'
-		},
 		body: content,
 		json: true
 	};


### PR DESCRIPTION
There could be something I'm missing here. So feel free to reject this PR if my assumptions are incorrect.

We are sending JSON to the API here. It doesn't make sense to set the `Content-Type` to 'application/x-www-form-urlencoded'. Apple's API seems to completely disregard the `Content-Type` header in most cases. 

Furthermore, because the `json` option is set to `true` Request is doing its own JSON serialisation on the  Javascript object set on the `body` option, and setting the `content-type` header to 'application/json' regardless. See [Request Documentation](https://github.com/request/request) for more information on the consequences of setting the `json` flag. 

There is an additional upstream bug here in Request that causes it to send the header twice with different a different case because Request and in-app-purchase's option use different casing. In this module this results in the following headers being sent with a request: 
```
Content-Type: application/x-www-form-urlencoded
content-type: application/json
```