### PR TITLE
Accessing API error codes

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,10 +51,7 @@ module.exports.validate = function (service, receipt, cb) {
 			return cb(new Error('invalid service given: ' + service));
 	}
 	validator(receipt, function (error, response) {
-		if (error) {
-			return cb(error);
-		}
-		cb(null, response);
+		cb(error, response);
 	});
 };
 


### PR DESCRIPTION
I work with iTunes in-app purchases and I need to know the exact error code returned by API (21002, 21006 etc.) and I think it should be implemented. All we need is just to pass a response along with an error object.