### PR TITLE
Handle receipts if they are string based

### DIFF
--- a/lib/google.js
+++ b/lib/google.js
@@ -119,9 +119,13 @@ module.exports.setup = function (cb) {
 * receipt = { data: 'stringified receipt data', signature: 'receipt signature' };
 * if receipt.data is an object, it silently stringifies it
 */
-module.exports.validatePurchase = function (dPubkey, receipt, cb) {
+module.exports.Purchase = function (dPubkey, receipt, cb) {
 
 	verbose.log(NAME, 'Validate this:', receipt);
+
+	if (typeof receipt === 'string') {
+		receipt = JSON.parse(receipt);
+	}
 
 	if (typeof receipt !== 'object') {
 		verbose.log(NAME, 'Failed: malformed receipt');

--- a/lib/google.js
+++ b/lib/google.js
@@ -119,7 +119,7 @@ module.exports.setup = function (cb) {
 * receipt = { data: 'stringified receipt data', signature: 'receipt signature' };
 * if receipt.data is an object, it silently stringifies it
 */
-module.exports.Purchase = function (dPubkey, receipt, cb) {
+module.exports.validatePurchase = function (dPubkey, receipt, cb) {
 
 	verbose.log(NAME, 'Validate this:', receipt);
 


### PR DESCRIPTION
I was having issues similar to the people posting in #56, until I realized that I had to send in an object not a string. Do you think it makes sense to handle the case when the user passes in a string?