### PR TITLE
Use path.join to concatenate paths

### DIFF
--- a/lib/google.js
+++ b/lib/google.js
@@ -67,8 +67,8 @@ module.exports.readConfig = function (configIn) {
 		return;
 	}
 
-	keyPathMap.sandbox = path.join(config.googlePublicKeyPath, sandboxPkey);
-	keyPathMap.live = path.join(config.googlePublicKeyPath, livePkey);
+	keyPathMap.sandbox = path.join(config.googlePublicKeyPath, sandboxPkey || "");
+	keyPathMap.live = path.join(config.googlePublicKeyPath, livePkey || "");
 
 	if (config.googleAccToken && config.googleRefToken && config.googleClientID && config.googleClientSecret) {
 		googleTokenMap.accessToken = config.googleAccToken;

--- a/lib/google.js
+++ b/lib/google.js
@@ -67,8 +67,8 @@ module.exports.readConfig = function (configIn) {
 		return;
 	}
 
-	keyPathMap.sandbox = path.join(config.googlePublicKeyPath, sandboxPkey || "");
-	keyPathMap.live = path.join(config.googlePublicKeyPath, livePkey || "");
+	keyPathMap.sandbox = path.join(config.googlePublicKeyPath || "", sandboxPkey);
+	keyPathMap.live = path.join(config.googlePublicKeyPath || "", livePkey);
 
 	if (config.googleAccToken && config.googleRefToken && config.googleClientID && config.googleClientSecret) {
 		googleTokenMap.accessToken = config.googleAccToken;
@@ -251,6 +251,7 @@ function checkSubscriptionStatus(data, cb) {
 			data.autoRenewing = body.autoRenewing;
 			data.expirationTime = body.expiryTimeMillis;
 			
+
 			state = constants.VALIDATION.SUCCESS;
 	
 			verbose.log(NAME, 'Successfully retrieved subscription info from', url, data);

--- a/lib/google.js
+++ b/lib/google.js
@@ -1,6 +1,7 @@
 var constants = require('../constants');
 var fs = require('fs');
 var crypto = require('crypto');
+var path = require('path');
 var async = require('./async');
 var request = require('request');
 var verbose = require('./verbose');
@@ -66,8 +67,8 @@ module.exports.readConfig = function (configIn) {
 		return;
 	}
 
-	keyPathMap.sandbox = config.googlePublicKeyPath + sandboxPkey;
-	keyPathMap.live = config.googlePublicKeyPath + livePkey;
+	keyPathMap.sandbox = path.join(config.googlePublicKeyPath, sandboxPkey);
+	keyPathMap.live = path.join(config.googlePublicKeyPath, livePkey);
 
 	if (config.googleAccToken && config.googleRefToken && config.googleClientID && config.googleClientSecret) {
 		googleTokenMap.accessToken = config.googleAccToken;

--- a/lib/google.js
+++ b/lib/google.js
@@ -527,9 +527,6 @@ function checkSubscriptionStatus(data, cb) {
 				return;
 			}
 
-			data.autoRenewing = body.autoRenewing;
-			data.expirationTime = body.expiryTimeMillis;
-			
 			_copyPurchaseDetails(data, body);
 
 			state = constants.VALIDATION.SUCCESS;


### PR DESCRIPTION
By using `path.join`, the user can define the path of the key with or without a trailing slash, and it will work properly.