### PR TITLE
Enabling products as well as subscription based purchases for Google Play

### DIFF
--- a/lib/google.js
+++ b/lib/google.js
@@ -226,9 +226,11 @@ function checkSubscriptionStatus(data, cb) {
 	var packageName = data.packageName;
 	var subscriptionID = data.productId;
 	var purchaseToken = data.purchaseToken;
+	var urlPurchaseTypeSegment = data.autoRenewing === undefined ? 'products' : 'subscriptions';
 
-	var url = 'https://www.googleapis.com/androidpublisher/v2/applications/' + packageName + 
-			'/purchases/subscriptions/' + subscriptionID + '/tokens/' + purchaseToken;
+	var url = 'https://www.googleapis.com/androidpublisher/v2/applications/' + packageName +
+		'/purchases/' + urlPurchaseTypeSegment + '/' + subscriptionID + '/tokens/' + purchaseToken;
+
 	var state;
 
 	var getSubInfo = function (next) {


### PR DESCRIPTION
Google Play managed products are failing re-checks since they should be using the purchased products  API instead of the purchased subscriptions API.

This is a quick change that allows products to go through as well. The rest seems to be working fine.

