### PR TITLE
Updated request module to latest version to prevent `in-app-purchase …

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"dependencies": {
 		"xmldom": "0.1.19",
 		"xml-crypto": "0.8.2",
-		"request": "2.75.0"
+		"request": "2.79.1"
 	},
 	"devDependencies": {
 		"mocha": "1.18.2"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"dependencies": {
 		"xmldom": "0.1.19",
 		"xml-crypto": "0.8.2",
-		"request": "2.79.1"
+		"request": "2.79.0"
 	},
 	"devDependencies": {
 		"mocha": "1.18.2"


### PR DESCRIPTION
…> request > node-uuid@1.4.7: use uuid module instead` deprecation notice