### PR TITLE
Google purchase state

### DIFF
--- a/lib/google.js
+++ b/lib/google.js
@@ -260,6 +260,7 @@ function checkSubscriptionStatus(data, cb) {
 				return;
 			}
 
+			data.purchaseState = body.purchaseState
 			data.autoRenewing = body.autoRenewing;
 			data.expirationTime = body.expiryTimeMillis;
 
@@ -337,6 +338,8 @@ function checkSubscriptionStatus(data, cb) {
 					next(error ? error : new Error(body.error));
 					return;
 				}
+
+				data.purchaseState = body.purchaseState
 				data.autoRenewing = body.autoRenewing;
 				data.expirationTime = body.expiryTimeMillis;
 				state = constants.VALIDATION.SUCCESS;


### PR DESCRIPTION
For purchases that have been cancelled or refunded, Google updates the
“purchaseState” status code 1 or 2 respectively. By default, it’s 0, if
the item is “purchased”

“The purchase state of the order. Possible values are 0 (purchased), 1
(canceled), or 2 (refunded).”