### PR TITLE
chore(package): update request to 2.81.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"dependencies": {
 		"xmldom": "0.1.19",
 		"xml-crypto": "0.8.2",
-		"request": "2.79.0"
+		"request": "2.81.0"
 	},
 	"devDependencies": {
 		"mocha": "1.18.2"


### PR DESCRIPTION
Currently, we pull a version of request that comes with some known-to-be-vulnerable dependency -- see https://snyk.io/test/npm/in-app-purchase
Trying to address this, bumping request to 2.81.0