### PR TITLE
Passing validated receipt data with an error when using promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,8 +19,7 @@ function handlePromisedFunctionCb(resolve, reject) {
 		if (error) {
 			var errorData = { error: error, status: null, message: null };
 			if (response !== null && typeof response === 'object') {
-				errorData.status = response.status;
-				errorData.message = response.message;
+				Object.assign(errorData, response);
 			}
 			return reject(JSON.stringify(errorData));
 		}


### PR DESCRIPTION
The existing approach doesn't pass validated receipt data when using promises. But sometimes we need this data (for example for Apple error 21006: 'This receipt is valid but the subscription has expired. When this status code is returned to your server, the receipt data is also decoded and returned as part of the response.').