### PR TITLE
If statusCode >= 399, return new Error with res.statusCode

### DIFF
--- a/lib/google.js
+++ b/lib/google.js
@@ -458,7 +458,7 @@ function validateSubscription(receipt, tokenMap, cb) {
 
 		if (res.statusCode >= 399) {
 			verbose.log(NAME, 'Product validation failed:', body, res.statusCode);
-			return cb(error, {
+			return cb(new Error('Status:' + res.statusCode), {
 				status: constants.VALIDATION.FAILURE,
 				message: body
 			});


### PR DESCRIPTION
In `_onSubscriptionValidate`, the case for res.statusCode >= 399 should return new Error('Status:' + res.statusCode) as `_onProductValidate`.