### PR TITLE
Bugfix: Resolve mishandling of user cancelled Google subscriptions

### DIFF
--- a/lib/google.js
+++ b/lib/google.js
@@ -27,6 +27,22 @@ var ENV_PUBLICKEY = {
 };
 var NAME = '<Google>';
 
+// See `cancelReason` at
+// https://developers.google.com/android-publisher/api-ref/purchases/subscriptions
+var CANCELLATION_REASON = {
+	// User cancelled the subscription. The subscription remains valid until its expiration time.
+	USER_CANCELLED: 0,
+
+	// Subscription was cancelled by the system, for example because of a billing problem.
+	SYSTEM_CANCELLED: 1,
+
+	// Subscription was replaced with a new subscription.
+	REPLACED: 2,
+
+	// Subscription was cancelled by the developer.
+	DEVELOPER_CANCELLED: 3
+}
+
 function isValidConfigKey(key) {
 	return key.match(/^google/);
 }
@@ -162,7 +178,7 @@ module.exports.validatePurchase = function (dPubkey, receipt, cb) {
 		clientId: googleTokenMap.clientID,
 		clientSecret: googleTokenMap.clientSecret,
 		refreshToken: googleTokenMap.refreshToken
-	}; 
+	};
 
 	// override pubkey to allow dynamically fed public key to validate
 	if (typeof dPubkey === 'string') {
@@ -172,11 +188,11 @@ module.exports.validatePurchase = function (dPubkey, receipt, cb) {
 	// dPubkey can be and object w/ clientId, clientSecret, and refreshToken
 	if (dPubkey && typeof dPubkey === 'object') {
 		if (dPubkey.clientId && dPubkey.clientSecret && dPubkey.refreshToken) {
-			verbose.log(NAME, 'Using dynamically fed google client ID, client secret, and refresh token:', dPubkey);		
+			verbose.log(NAME, 'Using dynamically fed google client ID, client secret, and refresh token:', dPubkey);
 			// override tokenMap
 			tokenMap.clientId = dPubkey.clientId;
 			tokenMap.clientSecret = dPubkey.clientSecret;
-			tokenMap.refreshToken = dPubkey.refreshToken;	
+			tokenMap.refreshToken = dPubkey.refreshToken;
 		}
 	}
 
@@ -221,7 +237,7 @@ module.exports.validatePurchase = function (dPubkey, receipt, cb) {
 			// sandbox worked
 			checkSubscriptionStatus(data, cb);
 		});
-		return;	
+		return;
 	}
 	// try live first
 	validateMethod(function (error, data) {
@@ -317,7 +333,7 @@ function validateProduct(receipt, tokenMap, cb) {
 			status: constants.VALIDATION.FAILURE,
 			message: 'client_id, client_secret, access_token and refres_token should be provided'
 		});
-	}	
+	}
 	auth(tokenMap, function (error, body) {
 		if (error) {
 			return cb(error, {
@@ -350,7 +366,7 @@ function validateProduct(receipt, tokenMap, cb) {
 			json: true
 		}, _onProductValidate);
 	});
-	
+
 	function _onProductValidate(error, res, body) {
 		if (error) {
 			return cb(error, {
@@ -415,7 +431,7 @@ function validateSubscription(receipt, tokenMap, cb) {
 			status: constants.VALIDATION.FAILURE,
 			message: 'client_id, client_secret, access_token and refres_token should be provided'
 		});
-	}	
+	}
 	auth(tokenMap, function (error, res) {
 		if (error) {
 			return cb(error, {
@@ -448,7 +464,7 @@ function validateSubscription(receipt, tokenMap, cb) {
 			json: true
 		}, _onSubscriptionValidate);
 	});
-	
+
 	function _onSubscriptionValidate(error, res, body) {
 		if (error) {
 			return cb(error, {
@@ -497,9 +513,10 @@ module.exports.getPurchaseData = function (purchase, options) {
 		} else if (purchase.expirationTime <= now) {
 			return [];
 		} else if (
-			purchase.userCancellationTimeMillis &&
-			purchase.userCancellationTimeMillis <= now
+			purchase.cancelReason &&
+			purchase.cancelReason !== CANCELLATION_REASON.USER_CANCELLED
 		) {
+			// User cancellations do not not void the subscription.
 			return [];
 		}
 	}
@@ -516,11 +533,18 @@ module.exports.getPurchaseData = function (purchase, options) {
 	if (purchase.expiryTimeMillis) {
 		purchaseInfo.expirationDate = purchase.expiryTimeMillis;
 	}
+
+	// User cancellations do not not void the subscription.
+	// See `userCancellationTimeMillis` at
+	// https://developers.google.com/android-publisher/api-ref/purchases/subscriptions
 	if (
-		purchase.userCancellationTimeMillis &&
-		purchase.expiryTimeMillis !== purchase.userCancellationTimeMillis
+		purchase.cancelReason &&
+		purchase.cancelReason !== CANCELLATION_REASON.USER_CANCELLED
 	) {
-		purchaseInfo.cancellationDate = purchase.userCancellationTimeMillis;
+		// Artificially promoting the expiryTimeMillis to the cancellation date for
+		// use by the isExpired utility function. Google does not provide a cancellation
+		// date for non-user cancelled reasons.
+		purchaseInfo.cancellationDate = purchase.expiryTimeMillis;
 	}
 
 	data.push(purchaseInfo);
@@ -626,7 +650,7 @@ function checkSubscriptionStatus(data, cb) {
 		}
 	};
 
-	var  recheck = function (next) {
+	var recheck = function (next) {
 		if (state === constants.VALIDATION.SUCCESS) {
 
 			verbose.log(NAME, 'Re-check subscription info:', url);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "in-app-purchase",
 	"description": "In-App-Purchase validation and subscription management for iOS, Android, Amazon, and Windows",
-	"version": "1.8.5",
+	"version": "1.8.6",
 	"author": {
 		"name": "Nobuyori Takahashi",
 		"email": "voltrue2@yahoo.com"
@@ -40,7 +40,9 @@
 	],
 	"jshintConfig": {
 		"node": true,
-		"predef": [ "Promise" ],
+		"predef": [
+			"Promise"
+		],
 		"bitwise": false,
 		"camelcase": false,
 		"curly": true,
@@ -66,6 +68,6 @@
 			"after": false,
 			"afterEach": false
 		}
-        },
+	},
 	"license": "MIT"
 }


### PR DESCRIPTION
### Changes

- adds enum for Google subscription cancellation reasons
- user cancellations now follow expiry checks for ignoreExpired option
- non user cancelled subscriptions now promote the expiry time for cancellation date
- updates package.json version `1.8.5` -> `1.8.6`


> ### Google IAP Documentation
> See cancelReason and userCancellationTimeMillis
> https://developers.google.com/android-publisher/api-ref/purchases/subscriptions