### PR TITLE
Critical bug fix: getPurchaseData for apple does not fetch latest_receipt_info

### DIFF
--- a/lib/apple.js
+++ b/lib/apple.js
@@ -217,7 +217,7 @@ module.exports.getPurchaseData = function (purchase, options) {
 		// iOS 6+
 		var tids = [];
 		var list = purchase.receipt[REC_KEYS.IN_APP];
-		var lri = purchase.receipt[REC_KEYS.LRI];
+		var lri = purchase[REC_KEYS.LRI];
 		if (lri && Array.isArray(lri)) {
 			list = list.concat(lri);
 		}


### PR DESCRIPTION
apple bugfix: not fetching from latest receipts