### PR TITLE
fix sort semantics

### DIFF
--- a/lib/apple.js
+++ b/lib/apple.js
@@ -227,7 +227,7 @@ module.exports.getPurchaseData = function (purchase, options) {
 		purchase_date_ms DESC
 		*/
 		list.sort(function (a, b) {
-			return parseInt(b[REC_KEYS.PURCHASE_DATE_MS], 10) > parseInt(a[REC_KEYS.PURCHASE_DATE_MS], 10);
+			return parseInt(b[REC_KEYS.PURCHASE_DATE_MS], 10) - parseInt(a[REC_KEYS.PURCHASE_DATE_MS], 10);
 		});
 		for (var i = 0, len = list.length; i < len; i++) {
 			var item = list[i];


### PR DESCRIPTION
Compare function should return negative, zero or positive number to indicate relative order. Returning boolean is incorrect and results in incorrect sorting for certain inputs