### PR TITLE
Return validated obj

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/lib/apple.js
+++ b/lib/apple.js
@@ -138,7 +138,7 @@ module.exports.validatePurchase = function (secret, receipt, cb) {
 				};
 				applyResponseData(validatedData, data);
 				verbose.log('<Apple>', prodPath, 'failed:', error, validatedData);
-                error.validatedData = validatedData;
+                                error.validatedData = validatedData;
 				return next(error);
 			}
 			// apple responded with error
@@ -165,7 +165,7 @@ module.exports.validatePurchase = function (secret, receipt, cb) {
 				};
 				applyResponseData(validatedData, data);
 				verbose.log('<Apple>', prodPath, 'failed:', validatedData);
-                err.validatedData = validatedData;
+                                err.validatedData = validatedData;
 				return next(err);		
 			}
 
@@ -197,7 +197,7 @@ module.exports.validatePurchase = function (secret, receipt, cb) {
 				};
 				applyResponseData(validatedData, data);
 				verbose.log('<Apple>', sandboxPath, 'failed:', error, validatedData);
-                error.validatedData = validatedData;
+                                error.validatedData = validatedData;
 				return next(error);
 			}
 			if (data.status > 0) {

--- a/lib/apple.js
+++ b/lib/apple.js
@@ -138,6 +138,7 @@ module.exports.validatePurchase = function (secret, receipt, cb) {
 				};
 				applyResponseData(validatedData, data);
 				verbose.log('<Apple>', prodPath, 'failed:', error, validatedData);
+                err.validatedData = validatedData;
 				return next(error);
 			}
 			// apple responded with error
@@ -164,6 +165,7 @@ module.exports.validatePurchase = function (secret, receipt, cb) {
 				};
 				applyResponseData(validatedData, data);
 				verbose.log('<Apple>', prodPath, 'failed:', validatedData);
+                err.validatedData = validatedData;
 				return next(err);		
 			}
 
@@ -195,6 +197,7 @@ module.exports.validatePurchase = function (secret, receipt, cb) {
 				};
 				applyResponseData(validatedData, data);
 				verbose.log('<Apple>', sandboxPath, 'failed:', error, validatedData);
+                err.validatedData = validatedData;
 				return next(error);
 			}
 			if (data.status > 0) {
@@ -208,6 +211,7 @@ module.exports.validatePurchase = function (secret, receipt, cb) {
 				};
 				applyResponseData(validatedData, data);
 				verbose.log('<Apple>', sandboxPath, 'failed:', validatedData);
+				err.validatedData = validatedData;
 				return next(err);		
 			}
 			// sandbox validated

--- a/lib/apple.js
+++ b/lib/apple.js
@@ -138,7 +138,7 @@ module.exports.validatePurchase = function (secret, receipt, cb) {
 				};
 				applyResponseData(validatedData, data);
 				verbose.log('<Apple>', prodPath, 'failed:', error, validatedData);
-                                error.validatedData = validatedData;
+                               error.validatedData = validatedData;
 				return next(error);
 			}
 			// apple responded with error
@@ -165,7 +165,7 @@ module.exports.validatePurchase = function (secret, receipt, cb) {
 				};
 				applyResponseData(validatedData, data);
 				verbose.log('<Apple>', prodPath, 'failed:', validatedData);
-                                err.validatedData = validatedData;
+                               err.validatedData = validatedData;
 				return next(err);		
 			}
 
@@ -197,7 +197,7 @@ module.exports.validatePurchase = function (secret, receipt, cb) {
 				};
 				applyResponseData(validatedData, data);
 				verbose.log('<Apple>', sandboxPath, 'failed:', error, validatedData);
-                                error.validatedData = validatedData;
+                               error.validatedData = validatedData;
 				return next(error);
 			}
 			if (data.status > 0) {

--- a/lib/apple.js
+++ b/lib/apple.js
@@ -138,7 +138,7 @@ module.exports.validatePurchase = function (secret, receipt, cb) {
 				};
 				applyResponseData(validatedData, data);
 				verbose.log('<Apple>', prodPath, 'failed:', error, validatedData);
-                err.validatedData = validatedData;
+                error.validatedData = validatedData;
 				return next(error);
 			}
 			// apple responded with error
@@ -197,7 +197,7 @@ module.exports.validatePurchase = function (secret, receipt, cb) {
 				};
 				applyResponseData(validatedData, data);
 				verbose.log('<Apple>', sandboxPath, 'failed:', error, validatedData);
-                err.validatedData = validatedData;
+                error.validatedData = validatedData;
 				return next(error);
 			}
 			if (data.status > 0) {


### PR DESCRIPTION
in both sandbox and prod, often the validated receipt object needs to be returned along with the error so i've appended it to the error object before returning.