### PR TITLE
fix internal function typo: 'isExipred'

### DIFF
--- a/lib/apple.js
+++ b/lib/apple.js
@@ -38,7 +38,7 @@ var liveHost = 'buy.itunes.apple.com';
 var path = '/verifyReceipt';
 var testMode = false;
 
-function isExipred(responseData) {
+function isExpired(responseData) {
     if (responseData[REC_KEYS.LRI] && responseData[REC_KEYS.LRI][REC_KEYS.EXPIRES_DATE]) {
         var exp = parseInt(responseData[REC_KEYS.LRI][REC_KEYS.EXPIRES_DATE]);
         if (exp > Date.now()) {
@@ -143,7 +143,7 @@ module.exports.validatePurchase = function (secret, receipt, cb) {
             }
             // apple responded with error
             if (data.status > 0 && data.status !== 21007 && data.status !== 21002) {
-                if (data.status === 21006 && !isExipred(data)) {
+                if (data.status === 21006 && !isExpired(data)) {
                     /* valid subscription receipt,
                     but cancelled and it has not been expired
                     status code is 21006 for both expired receipt and cancelled receipt...


### PR DESCRIPTION
Just a small typo on an internal function isExpired (apple.js)