### PR TITLE
Fix response type on validating google service account

### DIFF
--- a/lib/googleAPI.js
+++ b/lib/googleAPI.js
@@ -145,7 +145,8 @@ function _getToken(clientEmail, privateKey, cb) {
         body: 'grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=' + token,
         headers: {
             'content-type': 'application/x-www-form-urlencoded'
-        }
+        },
+        json: true
     };
     verbose.log(NAME, 'Get token with', clientEmail, '\n', privateKey);
     request(params, function (error, res, body) {


### PR DESCRIPTION
### Issue
* It closes #214.
* The validation response body is string. So, `body.access_token` is `undefined`.

### Solution
* Set `json: true` to request params.