### PR TITLE
parseUnityReceipt: Add missing field for Google Service Account usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,20 @@ If you are using Google service account instead of OAuth for Google, the receipt
 }
 ```
 
+### Google Play Using Google Service Account (with Unity receipt)
+
+If you are using Google service account with unity receipt, you need to add a 'Subscription' field to your unity receipt.
+The receipt should look like:
+
+```
+{
+    Store: 'The name of the store in use, such as GooglePlay or AppleAppStore',
+    TransactionID: 'This transaction's unique identifier, provided by the store',
+    Payload: 'Varies by platform, see [Unity Receipt Documentation](https://docs.unity3d.com/Manual/UnityIAPPurchaseReceipts.html)',
+    Subscription: true/false // if the receipt is a subscription, then true
+}
+```
+
 ### Amazon
 
 An Amazon's receipt contains the following:

--- a/index.js
+++ b/index.js
@@ -334,9 +334,15 @@ function parseUnityReceipt(receipt) {
                     throw error;
                 }
             }
+            var payloadContent = JSON.parse(receipt.Payload.json);
             return {
                 data: receipt.Payload.json,
-                signature: receipt.Payload.signature
+                signature: receipt.Payload.signature,
+                // add field necessary to use google service account
+                packageName: payloadContent.packageName,
+                productId: payloadContent.productId,
+                purchaseToken: payloadContent.purchaseToken,
+                subscription: (receipt.Subscription !== undefined && receipt.Subscription)
             };
         case constants.UNITY.AMAZON:
             if (typeof receipt.Payload === 'string') {


### PR DESCRIPTION
To allow using Google Service Account with unity receipt with minimal changes to the unity receipt.

Adds packageName, productId, purchaseToken, subscription field to the receipt.

googleAPI.validatePurchase will not workd without thoses fields.