### PR TITLE
fix: make sure request defaults are passed to GoogleAPI

### DIFF
--- a/lib/google.js
+++ b/lib/google.js
@@ -109,9 +109,9 @@ module.exports.readConfig = function (configIn) {
     }
 
     // googleServiceAccount { client_email, private_key } from Google API service account JSON file
-    if (config.googleServiceAccount) {
+    if (configIn.googleServiceAccount) {
         useGoogleApi = true;
-        googleApi.config(config.googleServiceAccount);
+        googleApi.config(configIn);
     }
 };
 

--- a/lib/googleAPI.js
+++ b/lib/googleAPI.js
@@ -28,15 +28,21 @@ module.exports = {
     validatePurchase: validatePurchase
 };
 
-function config(_conf) {
-    if (!_conf.clientEmail) {
+function config(inConfig) {
+    var serviceAccount = inConfig.googleServiceAccount;
+
+    if (!serviceAccount.clientEmail) {
         throw new Error('Google API requires client email');
     }
-    if (!_conf.privateKey) {
+    if (!serviceAccount.privateKey) {
         throw new Error('Google API requires private key');
     }
-    conf.clientEmail = _conf.clientEmail;
-    conf.privateKey = _conf.privateKey;
+    conf.clientEmail = serviceAccount.clientEmail;
+    conf.privateKey = serviceAccount.privateKey;
+
+    if (inConfig.requestDefaults) {
+        request = request.defaults(inConfig.requestDefaults);
+    }
 }
 
 /**
@@ -170,11 +176,11 @@ function _getValidationUrl(receipt, token) {
     switch (receipt.subscription) {
         case true:
             url = SUBSCR_VAL;
-        break;
+            break;
         case false:
         default:
             url = PRODUCT_VAL;
-        break;
+            break;
     }
     return util.format(
         url,

--- a/lib/googleAPI.js
+++ b/lib/googleAPI.js
@@ -41,6 +41,7 @@ function config(inConfig) {
     conf.privateKey = serviceAccount.privateKey;
 
     if (inConfig.requestDefaults) {
+        verbose.log(NAME, 'Setting request defaults:', { requestDefaults: inConfig.requestDefaults });
         request = request.defaults(inConfig.requestDefaults);
     }
 }
@@ -99,6 +100,7 @@ function validatePurchase(_googleServiceAccount, receipt, cb) {
             json: true
         };
         request(params, function (error, res, body) {
+            verbose.log(NAME, 'Response:', { error, res: res.toJSON(), body });
             if (error) {
                 return cb(error, { status: constants.VALIDATION.FAILURE, message: body });
             }
@@ -160,6 +162,7 @@ function _getToken(clientEmail, privateKey, cb) {
     };
     verbose.log(NAME, 'Get token with', clientEmail, '\n', privateKey);
     request(params, function (error, res, body) {
+        verbose.log(NAME, 'Response:', { error, res: res.toJSON(), body });
         if (error) {
             return cb(error);
         }


### PR DESCRIPTION
The `GoogleAPI` piece of the library ignores the `requestDefaults` being passed as config. This PR allows `GoogleAPI` to receive the incoming configs and set the request defaults.