### PR TITLE
Apple Sandbox validation - Check for empty data

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,12 +18,12 @@ var amazon;
 function handlePromisedFunctionCb(resolve, reject) {
     return function _handlePromisedCallback(error, response) {
         if (error) {
-            var errorData = { error: error, status: null, message: null };
-            if (response !== null && typeof response === 'object') {
-                errorData.status = response.status;
-                errorData.message = response.message;
+            if (response !== null && typeof response === 'object' && response.status && response.message) {
+                error = new Error()
+                error.status = response.status;
+                error.message = response.message;
             }
-            return reject(JSON.stringify(errorData), response);
+            return reject(error, response);
         }
         return resolve(response);
     };
@@ -64,7 +64,7 @@ module.exports.setup = function (cb) {
             amazon.setup(next);
         },
         function (next) {
-            facebook.setup(next);      
+            facebook.setup(next);
         },
     ], cb);
 };

--- a/lib/apple.js
+++ b/lib/apple.js
@@ -192,6 +192,9 @@ module.exports.validatePurchase = function (secret, receipt, cb) {
         send(sandboxPath, content, function (error, res, data) {
             verbose.log('<Apple>', sandboxPath, 'validation response:', data);
             if (error || !data) {
+                if (!error) {
+                  error = new Error('Unknown');
+                }
                 // 1 is unknown
                 status = data ? data.status : 1;
                 validatedData = {

--- a/lib/apple.js
+++ b/lib/apple.js
@@ -191,10 +191,10 @@ module.exports.validatePurchase = function (secret, receipt, cb) {
         verbose.log('<Apple> Try validate against sandbox:', sandboxPath);
         send(sandboxPath, content, function (error, res, data) {
             verbose.log('<Apple>', sandboxPath, 'validation response:', data);
-            if (error || !data) {
-                if (!error) {
-                  error = new Error('Unknown');
-                }
+            if (!data) {
+                error = new Error('Unknown');
+            }
+            if (error) {
                 // 1 is unknown
                 status = data ? data.status : 1;
                 validatedData = {

--- a/lib/apple.js
+++ b/lib/apple.js
@@ -191,7 +191,7 @@ module.exports.validatePurchase = function (secret, receipt, cb) {
         verbose.log('<Apple> Try validate against sandbox:', sandboxPath);
         send(sandboxPath, content, function (error, res, data) {
             verbose.log('<Apple>', sandboxPath, 'validation response:', data);
-            if (error) {
+            if (error || !data) {
                 // 1 is unknown
                 status = data ? data.status : 1;
                 validatedData = {


### PR DESCRIPTION
Starting on April 3, 2020 Apple Sandbox validation started to fail,

As I've debugged, the `data` variable is empty. most probably this is Apple's fault, 
but anyway this causes to an unhandled exception.
```
TypeError: Cannot read property 'status' of undefined
    at /opt/someproj/node_modules/in-app-purchase/lib/apple.js:207:22
    at Request._callback (/opt/someproj/API/node_modules/in-app-purchase/lib/apple.js:410:16)
    at Request.self.callback (/opt/someproj/node_modules/request/request.js:185:22)
    at emitTwo (events.js:126:13)
    at Request.emit (events.js:214:7)
    at Request.<anonymous> (/opt/someproj/node_modules/request/request.js:1161:10)
    at emitOne (events.js:116:13)
    at Request.emit (events.js:211:7)
    at IncomingMessage.<anonymous> (/opt/someproj/node_modules/request/request.js:1083:12)
    at Object.onceWrapper (events.js:313:30)
    at emitNone (events.js:111:20)
    at IncomingMessage.emit (events.js:208:7)
    at endReadableNT (_stream_readable.js:1055:12)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
``` 

This happens as there is a reference to `data.status` without checking `data` for undefined.