### PR TITLE
[Bug] Check parsed JSON receipt if it contains the purchaseToken field for Google Play

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ module.exports.getService = function (receipt) {
         }
         if (parsed.signature) {
             return module.exports.GOOGLE;
-        } else if (receipt.purchaseToken) {
+        } else if (parsed.purchaseToken) {
             return module.exports.GOOGLE;
         } else {
             return module.exports.AMAZON;


### PR DESCRIPTION
Currently, to determine if the platform type of the receipt is Google Play, there are two cases:

- If the receipt passed into `iap.validate` is an object, then the code checks if `receipt.signature` or `receipt.purchaseToken` exists.
- If the receipt passed into `iap.validate` is a string, then the code first parses the receipt into an object (called `parsed`), then it is supposed to check if `parsed.signature` or `parsed.purchaseToken` exists.

However, for the second condition the code never checks `parsed.purchaseToken`, instead checking whether `receipt.purchaseToken` exists twice. 

As a result, when a Google Play receipt string that uses service account for validation is passed into `iap.validate`, the package interprets it as an Amazon receipt since the receipt will not contain `parsed.signature`. It only contains `parsed.purchaseToken`, which is never checked.