### PR TITLE
Fix document typo error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ iap.config({
 
     /* Configurations for Google Play */
     googlePublicKeyPath: 'path/to/public/key/directory/', // this is the path to the directory containing iap-sanbox/iap-live files
-    googlePublicKeyStrSandBox: 'publicKeySandboxString', // this is the google iap-sandbox public key string
+    googlePublicKeyStrSandbox: 'publicKeySandboxString', // this is the google iap-sandbox public key string
     googlePublicKeyStrLive: 'publicKeyLiveString', // this is the google iap-live public key string
     googleAccToken: 'abcdef...', // optional, for Google Play subscriptions
     googleRefToken: 'dddd...', // optional, for Google Play subscritions


### PR DESCRIPTION
Fix document typo error to make the sandbox key name consistent with the program, or it will be always undefined to get the value.