### PR TITLE
checking for existence of purchaseToken property on the string rather…

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ module.exports.getService = function (receipt) {
         }
         if (parsed.signature) {
             return module.exports.GOOGLE;
-        } else if (receipt.purchaseToken) {
+        } else if (parsed.purchaseToken) {
             return module.exports.GOOGLE;
         } else {
             return module.exports.AMAZON;


### PR DESCRIPTION
… than the parsed object, so it always falls through to amazon